### PR TITLE
docs: clarify correlation comment

### DIFF
--- a/final_project.qmd
+++ b/final_project.qmd
@@ -525,7 +525,7 @@ def generate_sv_paths(
         
         # Apply correlation between asset price and variance processes (leverage effect)
         if rho != 0:  # Only apply correlation if rho is non-zero
-            # Cholesky decomposition for 2D correlated normal variables
+            # Create correlated normals using rho
             # This transforms Z2 to be correlated with Z1 with correlation coefficient rho
             Z2_corr = rho * Z1 + np.sqrt(1 - rho**2) * Z2
         else:
@@ -611,7 +611,7 @@ def generate_sv_paths(
         
         # Apply correlation between asset price and variance processes
         if rho != 0:  # Only if correlation is non-zero
-            # Cholesky decomposition for 2D correlated normal variables
+            # Create correlated normals using rho
             Z2_corr = rho * Z1 + np.sqrt(1 - rho**2) * Z2
         else:
             # No correlation adjustment needed


### PR DESCRIPTION
## Summary
- clarify comments about correlation in `generate_sv_paths`

## Testing
- `make help`
- `make render` *(fails: `Command not found: quarto`)*