### PR TITLE
Add GBM test

### DIFF
--- a/gbm.py
+++ b/gbm.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+
+def generate_gbm_paths(
+    S0: float,
+    r: float,
+    sigma: float,
+    T: float,
+    delta: float,
+    n_steps: int,
+    n_paths: int,
+    antithetic: bool = False,
+) -> np.ndarray:
+    """Generate asset price paths using Geometric Brownian Motion."""
+    dt = T / n_steps
+    nudt = (r - delta - 0.5 * sigma**2) * dt
+    sigsdt = sigma * np.sqrt(dt)
+
+    paths = np.zeros((n_paths, n_steps + 1))
+    paths[:, 0] = S0
+
+    if antithetic:
+        half_paths = n_paths // 2
+        Z = np.random.normal(0, 1, (half_paths, n_steps))
+        increments = np.exp(nudt + sigsdt * Z)
+        paths[:half_paths, 1:] = S0 * np.cumprod(increments, axis=1)
+        anti_increments = np.exp(nudt + sigsdt * (-Z))
+        paths[half_paths:, 1:] = S0 * np.cumprod(anti_increments, axis=1)
+    else:
+        Z = np.random.normal(0, 1, (n_paths, n_steps))
+        increments = np.exp(nudt + sigsdt * Z)
+        paths[:, 1:] = S0 * np.cumprod(increments, axis=1)
+
+    return paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "seaborn (>=0.13.2,<0.14.0)",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/test_gbm.py
+++ b/tests/test_gbm.py
@@ -1,0 +1,17 @@
+import numpy as np
+import gbm
+
+
+def test_generate_gbm_paths_shape_and_initial_price():
+    S0 = 100.0
+    r = 0.05
+    sigma = 0.2
+    T = 1.0
+    delta = 0.0
+    n_steps = 5
+    n_paths = 3
+
+    paths = gbm.generate_gbm_paths(S0, r, sigma, T, delta, n_steps, n_paths)
+
+    assert paths.shape == (n_paths, n_steps + 1)
+    assert np.all(paths[:, 0] == S0)


### PR DESCRIPTION
## Summary
- expose `generate_gbm_paths` in new `gbm.py`
- configure pytest as a dev dependency
- add regression test for `generate_gbm_paths`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*